### PR TITLE
Rename python lib 'moose => moose_kernels'

### DIFF
--- a/python-bindings/Cargo.toml
+++ b/python-bindings/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["", ""]
 edition = "2018"
 
 [lib]
-name = "moose"
+name = "moose_kernels"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/python-bindings/README.md
+++ b/python-bindings/README.md
@@ -10,7 +10,7 @@ pytest .
 ### Usage
 
 ```python
-from moose import ring_add
+from moose_kernels import ring_add
 import numpy as np
 
 a = np.array([1, 2, 3], dtype=np.uint64)

--- a/python-bindings/moose/__init__.py
+++ b/python-bindings/moose/__init__.py
@@ -1,1 +1,0 @@
-from .moose import *  # noqa

--- a/python-bindings/moose_kernels/__init__.py
+++ b/python-bindings/moose_kernels/__init__.py
@@ -1,0 +1,1 @@
+from .moose_kernels import *  # noqa

--- a/python-bindings/moose_kernels_test.py
+++ b/python-bindings/moose_kernels_test.py
@@ -1,5 +1,5 @@
 import numpy as np
-from moose import ring_add, ring_mul, ring_sub
+from moose_kernels import ring_add, ring_mul, ring_sub
 
 
 def test_ring_add_usual():

--- a/python-bindings/setup.py
+++ b/python-bindings/setup.py
@@ -7,11 +7,11 @@ install_requires = ['numpy']
 test_requires = install_requires + ['pytest']
 
 setup(
-    name='moose',
+    name='moose_kernels',
     version='0.1.0',
     description='Example of python extension using rust-numpy',
     rust_extensions=[RustExtension(
-        'moose.moose',
+        'moose_kernels.moose_kernels',
         './Cargo.toml',
     )],
     install_requires=install_requires,

--- a/python-bindings/src/lib.rs
+++ b/python-bindings/src/lib.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use std::num::Wrapping;
 
 #[pymodule]
-fn moose(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn moose_kernels(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     fn dynarray_to_ring64(arr: &PyReadonlyArrayDyn<u64>) -> Ring64Tensor {
         let arr_wrap = arr.as_array().mapv(Wrapping);
         Ring64Tensor(arr_wrap)


### PR DESCRIPTION
just renames to avoid conflict with prototype branch's python lib, per thread in #99 