### PR TITLE
Add build flags for mac-os to cargo config

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,3 +1,6 @@
 [build]
-rustflags = ["-Ctarget-feature=+aes", "-Clink-args=-undefined", "-Clink-arg=dynamic_lookup"]
+rustflags = ["-Ctarget-feature=+aes"]
 rustdocflags = ["-Ctarget-feature=+aes,+ssse3"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-Clink-args=-undefined", "-Clink-arg=dynamic_lookup"]


### PR DESCRIPTION
Fixes the issue with standalone builds on mac-os. As mentioned [here](https://github.com/PyO3/pyo3/issues/88), `setuptools-rust` adds some flags automatically on mac-os, so installation was working fine through Python. Adding these flags to the cargo config fixes the issue.