### PR TITLE
Fixedpoint encode/decode kernels

### DIFF
--- a/examples/replicated/main.py
+++ b/examples/replicated/main.py
@@ -1,6 +1,8 @@
 import argparse
 import logging
 
+import numpy as np
+
 from moose.edsl import add
 from moose.edsl import computation
 from moose.edsl import constant
@@ -30,10 +32,10 @@ rep = replicated_placement(name="rep", players=[alice, bob, carole])
 def my_comp():
 
     with alice:
-        x = constant(1)
+        x = constant(np.array([1], dtype=np.float64))
 
     with bob:
-        y = constant(2)
+        y = constant(np.array([2], dtype=np.float64))
 
     with rep:
         z = add(x, y)
@@ -45,6 +47,7 @@ def my_comp():
 
 
 concrete_comp = trace(my_comp)
+
 
 if __name__ == "__main__":
     runtime = TestRuntime()

--- a/moose/compiler/replicated_test.py
+++ b/moose/compiler/replicated_test.py
@@ -7,10 +7,10 @@ from moose.computation import replicated as replicated_ops
 from moose.computation import standard as standard_ops
 from moose.computation.base import Computation
 from moose.computation.host import HostPlacement
+from moose.computation.replicated import EncodedTensorType
 from moose.computation.replicated import ReplicatedPlacement
 from moose.computation.replicated import ReplicatedSetupType
 from moose.computation.replicated import ReplicatedTensorType
-from moose.computation.replicated import RingTensorType
 from moose.computation.standard import TensorType
 
 
@@ -128,7 +128,7 @@ class ReplicatedTest(parameterized.TestCase):
                 name="encode_0",
                 inputs={"value": "alice_input"},
                 placement_name="rep",
-                output_type=RingTensorType(),
+                output_type=EncodedTensorType(datatype="fixed64"),
                 scaling_factor=2 ** 16,
             )
         )
@@ -137,7 +137,7 @@ class ReplicatedTest(parameterized.TestCase):
                 name="encode_1",
                 inputs={"value": "bob_input"},
                 placement_name="rep",
-                output_type=RingTensorType(),
+                output_type=EncodedTensorType(datatype="fixed64"),
                 scaling_factor=2 ** 16,
             )
         )
@@ -175,7 +175,7 @@ class ReplicatedTest(parameterized.TestCase):
                 inputs={"setup": "replicated_setup_0", "value": "replicated_add_0"},
                 recipient_name="dave",
                 placement_name="rep",
-                output_type=RingTensorType(),
+                output_type=EncodedTensorType(datatype="fixed64"),
             )
         )
         expected_comp.add_operation(
@@ -185,7 +185,6 @@ class ReplicatedTest(parameterized.TestCase):
                 placement_name="rep",
                 output_type=TensorType(datatype="float"),
                 scaling_factor=2 ** 16,
-                bound=2 ** 30,
             )
         )
         expected_comp.add_operation(
@@ -207,7 +206,7 @@ class ReplicatedTest(parameterized.TestCase):
                 inputs={"setup": "replicated_setup_0", "value": "replicated_add_0"},
                 recipient_name="eric",
                 placement_name="rep",
-                output_type=RingTensorType(),
+                output_type=EncodedTensorType(datatype="fixed64"),
             )
         )
         expected_comp.add_operation(
@@ -217,7 +216,6 @@ class ReplicatedTest(parameterized.TestCase):
                 placement_name="rep",
                 output_type=TensorType(datatype="float"),
                 scaling_factor=2 ** 16,
-                bound=2 ** 30,
             )
         )
         expected_comp.add_operation(

--- a/moose/compiler/ring.py
+++ b/moose/compiler/ring.py
@@ -5,12 +5,10 @@ from typing import Optional
 
 from moose.compiler.primitives import Seed
 from moose.compiler.standard import Shape
-from moose.compiler.standard import StandardTensor
 from moose.computation.base import Computation
 from moose.computation.base import Operation
 from moose.computation.ring import FillTensorOperation
 from moose.computation.ring import RingAddOperation
-from moose.computation.ring import RingFromOperation
 from moose.computation.ring import RingMulOperation
 from moose.computation.ring import RingSampleOperation
 from moose.computation.ring import RingShapeOperation
@@ -23,18 +21,6 @@ class RingTensor:
     computation: Computation = field(repr=False)
     context: Any = field(repr=False)
     shape: Optional[Shape] = None
-
-
-def ring_from(x: StandardTensor) -> RingTensor:
-    assert isinstance(x, StandardTensor)
-    assert x.datatype == "int64"
-    y_op = RingFromOperation(
-        name=x.context.get_fresh_name("ring_from"),
-        inputs={"value": x.op.name},
-        placement_name=x.op.placement_name,
-    )
-    x.computation.add(y_op)
-    return RingTensor(op=y_op, computation=x.computation, context=x.context)
 
 
 def ring_shape(tensor: RingTensor, placement_name):

--- a/moose/compiler/standard.py
+++ b/moose/compiler/standard.py
@@ -5,9 +5,7 @@ from typing import Optional
 
 from moose.computation.base import Computation
 from moose.computation.base import Operation
-from moose.computation.standard import CastOperation
 from moose.computation.standard import MulOperation
-from moose.computation.standard import TensorType
 
 
 @dataclass
@@ -39,18 +37,4 @@ def standard_mul(x: StandardTensor, y: StandardTensor) -> StandardTensor:
     x.computation.add(z_op)
     return StandardTensor(
         op=z_op, datatype=x.datatype, computation=x.computation, context=x.context,
-    )
-
-
-def standard_cast(x: StandardTensor, datatype) -> StandardTensor:
-    assert isinstance(x, StandardTensor)
-    y_op = CastOperation(
-        name=x.context.get_fresh_name("cast"),
-        inputs={"value": x.op.name},
-        placement_name=x.op.placement_name,
-        output_type=TensorType(datatype=datatype),
-    )
-    x.computation.add(y_op)
-    return StandardTensor(
-        op=y_op, datatype=datatype, computation=x.computation, context=x.context,
     )

--- a/moose/computation/replicated.py
+++ b/moose/computation/replicated.py
@@ -26,6 +26,11 @@ class ReplicatedTensorType(ValueType):
 
 
 @dataclass
+class EncodedTensorType(ValueType):
+    datatype: str
+
+
+@dataclass
 class ReplicatedOperation(Operation):
     pass
 
@@ -43,7 +48,7 @@ class ShareOperation(ReplicatedOperation):
 @dataclass
 class RevealOperation(ReplicatedOperation):
     recipient_name: str
-    output_type: ValueType = RingTensorType()
+    output_type: ValueType
 
 
 @dataclass
@@ -59,11 +64,22 @@ class MulOperation(ReplicatedOperation):
 @dataclass
 class EncodeOperation(ReplicatedOperation):
     scaling_factor: int
-    output_type: ValueType = RingTensorType()
+    output_type: ValueType
 
 
 @dataclass
 class DecodeOperation(ReplicatedOperation):
     scaling_factor: int
-    bound: int
+    output_type: ValueType
+
+
+@dataclass
+class FixedpointEncodeOperation(ReplicatedOperation):
+    scaling_factor: int
+    output_type: ValueType = RingTensorType()
+
+
+@dataclass
+class FixedpointDecodeOperation(ReplicatedOperation):
+    scaling_factor: int
     output_type: ValueType

--- a/moose/computation/ring.py
+++ b/moose/computation/ring.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from moose.computation.base import Operation
 from moose.computation.base import ValueType
 from moose.computation.standard import ShapeType
-from moose.computation.standard import TensorType
 
 
 @dataclass
@@ -14,16 +13,6 @@ class RingTensorType(ValueType):
 @dataclass
 class RingOperation(Operation):
     pass
-
-
-@dataclass
-class RingFromOperation(RingOperation):
-    output_type: ValueType = RingTensorType()
-
-
-@dataclass
-class RingIntoOperation(RingOperation):
-    output_type: ValueType = TensorType(datatype="int64")
 
 
 @dataclass
@@ -57,6 +46,6 @@ class RingSampleOperation(RingOperation):
 
 
 @dataclass
-class FillTensorOperation(Operation):
+class FillTensorOperation(RingOperation):
     value: int
     output_type: ValueType = RingTensorType()

--- a/moose/computation/standard.py
+++ b/moose/computation/standard.py
@@ -29,11 +29,6 @@ class StandardOperation(Operation):
 
 
 @dataclass
-class CastOperation(StandardOperation):
-    output_type: ValueType
-
-
-@dataclass
 class InputOperation(StandardOperation):
     output_type: ValueType
 

--- a/moose/executor/executor.py
+++ b/moose/executor/executor.py
@@ -5,11 +5,13 @@ from typing import Any
 from moose.computation import host as host_ops
 from moose.computation import mpspdz as mpspdz_ops
 from moose.computation import primitives as primitives_ops
+from moose.computation import replicated as replicated_ops
 from moose.computation import ring as ring_ops
 from moose.computation import standard as standard_ops
 from moose.executor.kernels import host as host_kernels
 from moose.executor.kernels import mpspdz as mpspdz_kernels
 from moose.executor.kernels import primitives as primitives_kernels
+from moose.executor.kernels import replicated as replicated_kernels
 from moose.executor.kernels import ring as ring_kernels
 from moose.executor.kernels import standard as standard_kernels
 from moose.logger import get_logger
@@ -55,6 +57,12 @@ class AsyncExecutor:
             mpspdz_ops.MpspdzCallOperation: mpspdz_kernels.MpspdzCallKernel(networking),
             mpspdz_ops.MpspdzLoadOutputOperation: (
                 mpspdz_kernels.MpspdzLoadOutputKernel()
+            ),
+            replicated_ops.FixedpointEncodeOperation: (
+                replicated_kernels.FixedpointEncodeKernel()
+            ),
+            replicated_ops.FixedpointDecodeOperation: (
+                replicated_kernels.FixedpointDecodeKernel()
             ),
         }
 

--- a/moose/executor/kernels/replicated.py
+++ b/moose/executor/kernels/replicated.py
@@ -1,0 +1,18 @@
+from moose_kernels import replicated_decode
+from moose_kernels import replicated_encode
+
+from moose.computation.replicated import FixedpointDecodeOperation
+from moose.computation.replicated import FixedpointEncodeOperation
+from moose.executor.kernels.base import Kernel
+
+
+class FixedpointEncodeKernel(Kernel):
+    def execute_synchronous_block(self, op, session, value):
+        assert isinstance(op, FixedpointEncodeOperation)
+        return replicated_encode(value, op.scaling_factor)
+
+
+class FixedpointDecodeKernel(Kernel):
+    def execute_synchronous_block(self, op, session, value):
+        assert isinstance(op, FixedpointDecodeOperation)
+        return replicated_decode(value, op.scaling_factor)

--- a/rust/crypto/src/lib.rs
+++ b/rust/crypto/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod prng;
+pub mod replicated;
 pub mod ring;
 pub mod utils;

--- a/rust/crypto/src/replicated.rs
+++ b/rust/crypto/src/replicated.rs
@@ -1,0 +1,40 @@
+use crate::ring::Ring64Tensor;
+use ndarray::prelude::*;
+
+pub fn fixedpoint_encode(x: &ArrayViewD<f64>, scaling_factor: u64) -> Ring64Tensor {
+    let x_upshifted = x * scaling_factor as f64;
+    let x_converted = x_upshifted.mapv(|element| element as i64 as u64);
+    Ring64Tensor::from(x_converted)
+}
+
+pub fn fixedpoint_decode(x: &Ring64Tensor, scaling_factor: u64) -> ArrayD<f64> {
+    let x_converted = x.0.map(|element| element.0 as i64 as f64);
+    x_converted / scaling_factor as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replicated_fixedpoint() {
+        let x = array![1.0, -2.0, 3.0, -4.0]
+            .into_dimensionality::<IxDyn>()
+            .unwrap();
+
+        let scaling_factor = 2u64.pow(16);
+        let x_encoded = fixedpoint_encode(&x.view(), scaling_factor);
+        assert_eq!(
+            x_encoded,
+            Ring64Tensor::from(vec![
+                65536,
+                18446744073709420544,
+                196608,
+                18446744073709289472
+            ])
+        );
+
+        let x_decoded = fixedpoint_decode(&x_encoded, scaling_factor);
+        assert_eq!(x_decoded, x);
+    }
+}

--- a/rust/python-bindings/src/lib.rs
+++ b/rust/python-bindings/src/lib.rs
@@ -1,4 +1,5 @@
 use crypto::prng::AesRng;
+use crypto::replicated;
 use crypto::ring::{Dot, Fill, Ring64Tensor};
 use crypto::utils;
 use ndarray::ArrayD;
@@ -96,6 +97,28 @@ fn moose_kernels(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
         let res = Ring64Tensor::fill(&shape, el);
         let res_array = ring64_to_array(res);
         res_array.to_pyarray(py)
+    }
+
+    #[pyfn(m, "replicated_encode")]
+    fn replicated_encode<'py>(
+        py: Python<'py>,
+        x: PyReadonlyArrayDyn<f64>,
+        scaling_factor: u64,
+    ) -> &'py PyArrayDyn<u64> {
+        let x = x.as_array();
+        let y = replicated::fixedpoint_encode(&x, scaling_factor);
+        ring64_to_array(y).to_pyarray(py)
+    }
+
+    #[pyfn(m, "replicated_decode")]
+    fn replicated_decode<'py>(
+        py: Python<'py>,
+        x: PyReadonlyArrayDyn<u64>,
+        scaling_factor: u64,
+    ) -> &'py PyArrayDyn<f64> {
+        let x_ring = dynarray_to_ring64(&x);
+        let y = replicated::fixedpoint_decode(&x_ring, scaling_factor);
+        y.to_pyarray(py)
     }
 
     Ok(())


### PR DESCRIPTION
Note that this PR introduces higher-level (local) fixedpoint encoding/decoding ops, and changes the compiler to target these during lowering instead of the low-level ring operations previously targeted.