### PR TITLE
Prints task name and stack trace on exception

### DIFF
--- a/moose/executor/executor.py
+++ b/moose/executor/executor.py
@@ -106,7 +106,8 @@ class AsyncExecutor:
             output = session.values.get_future(key=op.name)
             tasks += [
                 asyncio.create_task(
-                    kernel.execute(op, session=session, output=output, **inputs)
+                    kernel.execute(op, session=session, output=output, **inputs),
+                    name=op.name,
                 )
             ]
         get_logger().debug(f"Exiting computation; session_id:{session.session_id}")
@@ -119,10 +120,13 @@ class AsyncExecutor:
         # execute kernels
         done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
         # address any errors that may have occurred
-        exceptions = [task.exception() for task in done if task.exception()]
-        for e in exceptions:
-            get_logger().exception(e)
-        if exceptions:
+        except_tasks = [task for task in done if task.exception()]
+        exceptions = []
+        for t in except_tasks:
+            exceptions.append(t.exception())
+            get_logger().error(f"Task {t.get_name()} caused an exception")
+            t.print_stack()
+        if len(exceptions) > 0:
             raise Exception(
                 f"One or more errors occurred in '{placement}: {exceptions}'"
             )

--- a/moose/executor/kernels/standard_test.py
+++ b/moose/executor/kernels/standard_test.py
@@ -321,6 +321,44 @@ class StandardKernelTest(parameterized.TestCase):
         asyncio.get_event_loop().run_until_complete(task)
         np.testing.assert_array_equal(executor.store["z"], expected_result)
 
+    def test_exception(self):
+        comp = Computation(operations={}, placements={})
+
+        alice = comp.add_placement(HostPlacement(name="alice"))
+
+        comp.add_operation(
+            standard_dialect.InputOperation(
+                name="x",
+                placement_name=alice.name,
+                inputs={},
+                output_type=TensorType(datatype="int64"),
+            )
+        )
+
+        # there is no networking so run_computation below will raise
+        # exception
+        comp.add_operation(
+            standard_dialect.SendOperation(
+                name="send_x",
+                placement_name=alice.name,
+                inputs={"value": "x"},
+                sender=alice.name,
+                receiver=alice.name,
+                rendezvous_key="0123456789",
+            )
+        )
+
+        executor = AsyncExecutor(networking=None)
+        task = executor.run_computation(
+            comp,
+            placement_instantiation={alice.name: alice.name},
+            placement=alice.name,
+            session_id="0123456789",
+            arguments={"x": 5},
+        )
+        with self.assertRaises(Exception):
+            asyncio.get_event_loop().run_until_complete(task)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In the AsyncExecutor all of the graph nodes are passed into a
asyncio.wait call. After all tasks are completed the call returns a done
list. This list can then be checked to see if any exceptions happen.
This PR makes that more helpful by printing which op caused the
exception and then also the stack trace from the task.