### PR TITLE
Add missing dependency in python-bindings 

### DIFF
--- a/rust/python-bindings/requirements-dev.txt
+++ b/rust/python-bindings/requirements-dev.txt
@@ -1,5 +1,6 @@
 absl-py~=0.11.0
 black==19.10b0
+dill==0.3.3
 flake8-black==0.1.1
 flake8-isort==4.0.0
 flake8==3.8.3


### PR DESCRIPTION
Found this missing dependency trying to run workers locally.