### PR TITLE
Versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,7 @@ clean:
 
 ci: fmt lint test
 
-.PHONY: build pydep pylib install fmt lint test ci
+release: ci
+	cd rust && cargo release --workspace --skip-publish
+
+.PHONY: build pydep pylib install fmt lint test ci release

--- a/README.md
+++ b/README.md
@@ -65,3 +65,25 @@ make fmt
 make lint
 make test
 ```
+
+### Releasing
+
+Follow these steps to release a new version:
+
+1. create a new branch from `main`, eg `git checkout -b new-release`
+
+2. run `make release`
+
+3. if successful then `git push` to create a new PR
+
+Once your PR has been merged to `main`:
+
+1. checkout main branch: `git checkout main`
+
+2. create a new tag *matching the version* of `python-bindings`: eg `git tag v{x.y.z}`
+
+3. push tag: `git push origin v{x.y.z}`
+
+4. create a release on GitHub based on your [tag](https://github.com/tf-encrypted/runtime/tags)
+
+If needed then tags on GitHub can be deleted using `git push --delete origin {tag-name}`

--- a/rust/moose/Cargo.toml
+++ b/rust/moose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moose"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 license = "MIT/Apache-2.0"
 authors = [""]
 description = ""

--- a/rust/pymoose/Cargo.toml
+++ b/rust/pymoose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pymoose"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 license = "MIT/Apache-2.0"
 authors = [""]
 description = ""

--- a/rust/pymoose/release.toml
+++ b/rust/pymoose/release.toml
@@ -1,0 +1,8 @@
+pre-release-replacements = [
+    {file="setup.py", search="version=\"[a-z0-9\\.-]+\"", replace="version=\"{{version}}\"", exactly=1},
+    {file="../../setup.py", search="version=\"[a-z0-9\\.-]+\"", replace="version=\"{{version}}\"", exactly=1},
+]
+post-release-replacements = [
+    {file="setup.py", search="version=\"[0-9\\.]+\"", replace="version=\"{{next_version}}\"", exactly=1},
+    {file="../../setup.py", search="version=\"[0-9\\.]+\"", replace="version=\"{{next_version}}\"", exactly=1},
+]

--- a/rust/pymoose/setup.py
+++ b/rust/pymoose/setup.py
@@ -8,7 +8,7 @@ test_requires = install_requires + ["pytest", "absl-py"]
 
 setup(
     name="pymoose",
-    version="0.1.0",
+    version="0.1.1-alpha.0",  # NOTE: auto-updated during release
     description="Python-bindings for Moose",
     rust_extensions=[RustExtension("pymoose.moose_kernels", "./Cargo.toml",)],
     install_requires=install_requires,

--- a/rust/release.toml
+++ b/rust/release.toml
@@ -1,0 +1,4 @@
+disable-publish = true
+disable-push = true
+pre-release-commit-message = "release {{version}} of {{crate_name}}"
+post-release-commit-message = "starting {{next_version}} of {{crate_name}}"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf8") as fh:
 
 setuptools.setup(
     name="moose",
-    version="0.0.0",
+    version="0.1.1-alpha.0",  # NOTE: auto-updated during release
     packages=setuptools.find_packages(),
     python_requires=">=3.6",
     install_requires=[],


### PR DESCRIPTION
This PR adds a (for now) manual release process as detailed in `README.md`.

Note that versioning of Python components is automated by `cargo release`; in particular, every release will fix the version of Python components to that of `pymoose` (previously `python-bindings`), although they can be bumped independently in-between releases if needed. This is in anticipation of Rust taking the lead in the near future.