### PR TITLE
Don't tag automatically on release

### DIFF
--- a/rust/release.toml
+++ b/rust/release.toml
@@ -1,4 +1,5 @@
 disable-publish = true
+disable-tag = true
 disable-push = true
 pre-release-commit-message = "release {{version}} of {{crate_name}}"
 post-release-commit-message = "starting {{next_version}} of {{crate_name}}"


### PR DESCRIPTION
This change avoids generating useless local tags.