### PR TITLE
Add custom Exception for ExecutionError

### DIFF
--- a/moose/executor/executor.py
+++ b/moose/executor/executor.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 from typing import Any
+from typing import List
 
 from moose.computation import fixedpoint as fixed_ops
 from moose.computation import host as host_ops
@@ -17,6 +18,12 @@ from moose.executor.kernels import standard as standard_kernels
 from moose.logger import get_logger
 from moose.logger import get_tracer
 from moose.utils import AsyncStore
+
+
+class ExecutionError(Exception):
+    def __init__(self, msg: str, exceptions: List[Exception]):
+        super().__init__(msg)
+        self.exceptions = exceptions
 
 
 @dataclasses.dataclass
@@ -148,8 +155,9 @@ class AsyncExecutor:
                 get_logger().error(f"Task {t.get_name()} caused an exception")
                 t.print_stack()
             if len(exceptions) > 0:
-                raise Exception(
-                    f"One or more errors occurred in '{placement}: {exceptions}'"
+                raise ExecutionError(
+                    f"One or more errors occurred in '{placement}': '{exceptions}'",
+                    exceptions,
                 )
 
     def schedule_execution(self, comp, placement):


### PR DESCRIPTION
This should allow upstream code i.e. be able to manage errors better.
For example, instead of erroring on all errors we could customize this
process to retry computations in certain cases.