### PR TITLE
Add timeout to the wait that runs all the nodes

### DIFF
--- a/moose/executor/executor.py
+++ b/moose/executor/executor.py
@@ -108,8 +108,7 @@ class AsyncExecutor:
         placement,
         session_id,
         arguments={},
-        # default timeout of 10 minutes
-        timeout=600,
+        timeout=None,
     ):
         physical_computation = self.compile_computation(logical_computation)
         execution_plan = self.schedule_execution(physical_computation, placement)


### PR DESCRIPTION
Added a timeout to cape-worker as well but I don't think these tasks
were getting cancelled since they were launched with a separate wait
call.