### PR TITLE
Refuse to re-run computations with same session id

### DIFF
--- a/moose/executor/executor.py
+++ b/moose/executor/executor.py
@@ -37,6 +37,7 @@ class Session:
 
 class AsyncExecutor:
     def __init__(self, networking, storage):
+        self.known_sessions = set()
         self.storage = storage  # NOTE: this is used by the test runtime in unit tests
         self.kernels = {
             standard_ops.InputOperation: standard_kernels.InputKernel(),
@@ -110,6 +111,13 @@ class AsyncExecutor:
         arguments={},
         timeout=None,
     ):
+        if session_id in self.known_sessions:
+            raise ValueError(
+                "Attempted to re-run a computation with the same session id, "
+                f"which is generally not safe; session_id:{session_id}"
+            )
+        self.known_sessions.add(session_id)
+
         physical_computation = self.compile_computation(logical_computation)
         execution_plan = self.schedule_execution(physical_computation, placement)
         session = Session(

--- a/moose/executor/executor_test.py
+++ b/moose/executor/executor_test.py
@@ -1,0 +1,62 @@
+import asyncio
+
+from absl.testing import parameterized
+
+from moose.computation import standard as standard_dialect
+from moose.computation.base import Computation
+from moose.computation.host import HostPlacement
+from moose.computation.standard import TensorType
+from moose.executor.executor import AsyncExecutor
+
+
+class ExecutorTest(parameterized.TestCase):
+    def test_rerun(self):
+        executor = AsyncExecutor(networking=None, storage=None)
+
+        comp = Computation(operations={}, placements={})
+        alice = comp.add_placement(HostPlacement(name="alice"))
+        comp.add_operation(
+            standard_dialect.ConstantOperation(
+                name="x",
+                placement_name=alice.name,
+                inputs={},
+                value=12345,
+                output_type=TensorType("int64"),
+            )
+        )
+
+        executor = AsyncExecutor(networking=None, storage=None)
+        task = executor.run_computation(
+            comp,
+            placement_instantiation={alice.name: alice.name},
+            placement=alice.name,
+            session_id="01234",
+        )
+        asyncio.get_event_loop().run_until_complete(task)
+
+        task = executor.run_computation(
+            comp,
+            placement_instantiation={alice.name: alice.name},
+            placement=alice.name,
+            session_id="01234",
+        )
+        with self.assertRaises(Exception):
+            asyncio.get_event_loop().run_until_complete(task)
+
+        executor = AsyncExecutor(networking=None, storage=None)
+        task = executor.run_computation(
+            comp,
+            placement_instantiation={alice.name: alice.name},
+            placement=alice.name,
+            session_id="56789",
+        )
+        asyncio.get_event_loop().run_until_complete(task)
+
+        task = executor.run_computation(
+            comp,
+            placement_instantiation={alice.name: alice.name},
+            placement=alice.name,
+            session_id="56789",
+        )
+        with self.assertRaises(Exception):
+            asyncio.get_event_loop().run_until_complete(task)


### PR DESCRIPTION
Re-using session ids is generally not secure from a cryptographic perspective. This PR attempts to detect such cases and fails fast. Note that since executor state is not persisted this can only be on a best-effort basis.