### PR TITLE
Add back networking error

### DIFF
--- a/rust/moose/src/error.rs
+++ b/rust/moose/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
 
     #[error("Compilation error: {0}")]
     Compilation(String),
+
+    #[error("Networking error: {0}")]
+    Networking(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
This PR add back the error for networking which is required by the worker.