### PR TITLE
Move dict literal into MemoryDataStore constructor

### DIFF
--- a/moose/storage/memory.py
+++ b/moose/storage/memory.py
@@ -2,8 +2,8 @@ from moose.storage.base import DataStore
 
 
 class MemoryDataStore(DataStore):
-    def __init__(self, initial_store={}):
-        self.store = initial_store
+    def __init__(self, initial_store=None):
+        self.store = initial_store or {}
 
     async def load(self, session_id, key, query):
         return self.store[key]


### PR DESCRIPTION
Small python bug leading to a memory leak where all MemoryDataStore objects (e.g. from different executors) were referring to the same underlying dictionary in memory.