### PR TITLE
Pin ndarray to 0.13.1

### DIFF
--- a/rust/pymoose/Cargo.toml
+++ b/rust/pymoose/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 anyhow = "~1.0"
 approx = "~0.4"
 maplit = "~1.0"
-numpy = "~0.13"
+numpy = "=0.13.1"
 ndarray = "~0.14"
 moose = { path = "../moose" }
 pyo3 = "~0.13"


### PR DESCRIPTION
Note that we should find a more general fix in the near term, this is just to get CI running again

Follow-up issue: https://github.com/tf-encrypted/runtime/issues/320