### PR TITLE
Value placements

### DIFF
--- a/rust/moose/src/compilation/spike.rs
+++ b/rust/moose/src/compilation/spike.rs
@@ -451,8 +451,8 @@ where
 #[derive(Clone, Debug, PartialEq)]
 pub struct SymbolicHandle<P> {
     op: String,
-     // NOTE if we had a handle to the graph we
-     // could perhaps derive the placement instead
+    // NOTE if we had a handle to the graph we
+    // could perhaps derive the placement instead
     plc: P,
 }
 


### PR DESCRIPTION
This PR requires each value to have a placement through the `Placed` trait, which is needed in certain operations such as sharing and revealing where both op's placement and the inputs placement are required.

Note that a decision is made via the `Placed` trait to only allow a single static placement type for each value type, eg `RingTensor` is fixed to `HostPlacement`. I don't know if this will cause problems down the line, but fixing the associated placement type helps ensure that kernels cannot fail by removing the need to eg `TryInto<HostPlacement>`. Note also that `FixedTensor`, which is used by the upper dialects, uses `enum Placement` as it's placement type since it's allowed on both host and replicated placements.