### PR TITLE
Init sodiumoxide

### DIFF
--- a/rust/moose/src/prng.rs
+++ b/rust/moose/src/prng.rs
@@ -185,16 +185,9 @@ impl AesRng {
 
     pub fn generate_random_key() -> [u8; SEED_SIZE] {
         let mut seed = [0u8; SEED_SIZE];
-        match sodiumoxide::init() {
-            Ok(()) => {
-                randombytes_into(&mut seed);
-                seed
-            }
-            Err(()) => {
-                // TODO: should this function return a Result<RngSeed> ?
-                panic!("failed to initialize sodiumoxide");
-            }
-        }
+        sodiumoxide::init().expect("failed to initialize sodiumoxide");
+        randombytes_into(&mut seed);
+        seed
     }
 
     /// Method to fetch a PRNG where its seed is taken from /dev/random

--- a/rust/moose/src/utils.rs
+++ b/rust/moose/src/utils.rs
@@ -3,21 +3,14 @@ use sodiumoxide::crypto::generichash;
 use crate::prng::{RngSeed, SEED_SIZE};
 
 pub fn derive_seed(key: &[u8], nonce: &[u8]) -> RngSeed {
-    match sodiumoxide::init() {
-        Ok(()) => {
-            let mut hasher = generichash::State::new(Some(SEED_SIZE), Some(key)).unwrap();
-            hasher.update(nonce).unwrap();
-            let h = hasher.finalize().unwrap();
+    sodiumoxide::init().expect("failed to initialize sodiumoxide");
+    let mut hasher = generichash::State::new(Some(SEED_SIZE), Some(key)).unwrap();
+    hasher.update(nonce).unwrap();
+    let h = hasher.finalize().unwrap();
 
-            let mut output: RngSeed = [0u8; SEED_SIZE];
-            output.copy_from_slice(h.as_ref());
-            output
-        }
-        Err(()) => {
-            // TODO: should this function return a Result<RngSeed> ?
-            panic!("failed to initialize sodiumoxide");
-        }
-    }
+    let mut output: RngSeed = [0u8; SEED_SIZE];
+    output.copy_from_slice(h.as_ref());
+    output
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I would normally prefer to avoid a `panic`, but it seems that the calling functions are not returning results, so it looks like it would take a bigger change in moose to start using result types to handle errors.