### PR TITLE
bugfix and small kernel improvements

### DIFF
--- a/moose/src/fixedpoint.rs
+++ b/moose/src/fixedpoint.rs
@@ -543,7 +543,7 @@ impl FixedpointMulOp {
         Ok(AbstractReplicatedFixedTensor {
             tensor: z,
             fractional_precision: x.fractional_precision + y.fractional_precision,
-            integral_precision: u32::max(x.fractional_precision, y.fractional_precision),
+            integral_precision: u32::max(x.integral_precision, y.integral_precision),
         })
     }
 }

--- a/moose/src/host.rs
+++ b/moose/src/host.rs
@@ -1965,21 +1965,12 @@ pub trait FromRawPlc<P, T> {
     fn from_raw_plc(raw_tensor: ArrayD<T>, plc: P) -> Self;
 }
 
-impl<P> FromRawPlc<P, u64> for HostRing64Tensor
+impl<P, T> FromRawPlc<P, T> for AbstractHostRingTensor<T>
 where
     P: Into<HostPlacement>,
+    T: Clone,
 {
-    fn from_raw_plc(raw_tensor: ArrayD<u64>, plc: P) -> HostRing64Tensor {
-        let tensor = raw_tensor.mapv(Wrapping).into_dyn();
-        AbstractHostRingTensor(tensor, plc.into())
-    }
-}
-
-impl<P> FromRawPlc<P, u128> for HostRing128Tensor
-where
-    P: Into<HostPlacement>,
-{
-    fn from_raw_plc(raw_tensor: ArrayD<u128>, plc: P) -> HostRing128Tensor {
+    fn from_raw_plc(raw_tensor: ArrayD<T>, plc: P) -> AbstractHostRingTensor<T> {
         let tensor = raw_tensor.mapv(Wrapping).into_dyn();
         AbstractHostRingTensor(tensor, plc.into())
     }

--- a/moose/src/kernels.rs
+++ b/moose/src/kernels.rs
@@ -1843,7 +1843,9 @@ constant_kernels![
     HostUint8Tensor,
     HostUint16Tensor,
     HostUint32Tensor,
-    HostUint64Tensor
+    HostUint64Tensor,
+    HostRing64Tensor,
+    HostRing128Tensor
 ];
 
 impl ConstantOp {


### PR DESCRIPTION
- found a small bug in the fixedpoint lowering for FixedpointMul
- generalized a kernel function that was identical across u64/u128
- added HostRing64Tensor and HostRing128Tensor ConstantOp kernels via `constant_values!` declaration