### PR TITLE
add install-dev target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,14 @@ pydep:
 	pip install -r pymoose/requirements-dev.txt
 
 pylib:
-	cd pymoose && python setup.py develop
+	cd pymoose && python setup.py install
 
 install: pydep pylib
+
+pylib-dev:
+	cd pymoose && python setup.py develop
+
+install-dev: pydep pylib-dev
 
 fmt:
 	cargo fmt


### PR DESCRIPTION
also fixes the `pip install` statements in Makefile (they were finding the `pymoose` lib on PyPI instead of the local Python package)