### PR TITLE
ShapeOp Compiler Fix

### DIFF
--- a/moose/src/computation.rs
+++ b/moose/src/computation.rs
@@ -825,6 +825,8 @@ impl Ty {
     pub fn merge(&self, another: &Ty) -> Option<Ty> {
         match self {
             Ty::Unknown => Some(*another),
+            // TODO: make sure another dtype is also a tensor
+            Ty::Tensor(TensorDType::Unknown) => Some(*another),
             _ => None,
         }
     }

--- a/pymoose/src/computation.rs
+++ b/pymoose/src/computation.rs
@@ -1208,9 +1208,8 @@ impl TryFrom<PyComputation> for Computation {
                         placement: map_placement(&placements, &op.placement_name)?,
                     }),
                     std_ShapeOperation(op) => Ok(Operation {
-                        // TODO (lvorona): We can actually use TensorDType::Unknown and let the type inference figure the type out.
                         kind: ShapeOp {
-                            sig: Signature::unary(Ty::Tensor(TensorDType::Float64), Ty::HostShape),
+                            sig: Signature::unary(Ty::Tensor(TensorDType::Unknown), Ty::HostShape),
                         }
                         .into(),
                         inputs: map_inputs(&op.inputs, &["x"])


### PR DESCRIPTION
Lex's fix for the compiler bugs that were unearthed while trying to add back the bias to the computation. This will allow the typing pass to fill in the type for a shape operation, and will fix type merging when the type is a tensor of unknown.