### PR TITLE
Hotfix for main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install runtime package.
         run: |
           . venv/bin/activate
-          make pylib-dev
+          make pylib
 
       - name: Lint check the runtime package.
         run: |

--- a/pymoose/requirements-dev.txt
+++ b/pymoose/requirements-dev.txt
@@ -6,6 +6,7 @@ flake8==3.8.3
 isort==5.4.2
 msgpack==1.0.2
 numpy==1.21.2
+onnx~=1.10.0
 pip~=21.2
 pytest==6.0.1
 setuptools-rust~=0.12.1


### PR DESCRIPTION
I broke a CMake target used by main CI (but not moose CI) in #739. This should fix it for the HEAD of main.