### PR TITLE
Update hardcoded precision for fixedpoint inputs

### DIFF
--- a/moose/src/encrypted/ops.rs
+++ b/moose/src/encrypted/ops.rs
@@ -48,7 +48,7 @@ impl InputOp {
         Ok(HostFixedAesTensor {
             tensor,
             // TODO(Morten) extract precision from sig
-            integral_precision: 46,
+            integral_precision: 24,
             fractional_precision: 40,
         })
     }

--- a/moose/src/replicated/input.rs
+++ b/moose/src/replicated/input.rs
@@ -88,7 +88,7 @@ impl InputOp {
             // TODO(jason,morten): figure out a good way to get this static type information
             //  from the Signature (improve Ty impl in values!)
             Ty::ReplicatedFixed64Tensor => Ok((14, 23)),
-            Ty::ReplicatedFixed128Tensor => Ok((46, 40)),
+            Ty::ReplicatedFixed128Tensor => Ok((24, 40)),
             _ => Err(Error::TypeMismatch {
                 expected: "ReplicatedFixedTensor".to_string(),
                 found: sig.ret(),


### PR DESCRIPTION
Precision values had been temporarily hardcoded for fixedpoint inputs. We changed the default integral precision of predictors to (24, 40) from (46, 40), but that change had not made its way into all of the kernels. This PR fixes that.