### PR TITLE
Unify concatenate op

### DIFF
--- a/moose/src/computation.rs
+++ b/moose/src/computation.rs
@@ -1063,7 +1063,6 @@ operators![
     Less,
     GreaterThan,
     // Floating-point operators
-    FloatingpointConcat,
     FloatingpointMean,
     // Additive operators
     AdtToRep,
@@ -1419,12 +1418,6 @@ pub struct FixedpointMeanOp {
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ShortName, ToTextual, FromTextual)]
 pub struct NegOp {
     pub sig: Signature,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ShortName, ToTextual, FromTextual)]
-pub struct FloatingpointConcatOp {
-    pub sig: Signature,
-    pub axis: u32,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ShortName, FromTextual)]

--- a/moose/src/execution/asynchronous.rs
+++ b/moose/src/execution/asynchronous.rs
@@ -366,7 +366,6 @@ impl Session for AsyncSession {
             FixedpointDecode(op) => DispatchKernel::compile(&op, plc)?,
             FixedpointMean(op) => DispatchKernel::compile(&op, plc)?,
             Sign(op) => DispatchKernel::compile(&op, plc)?,
-            FloatingpointConcat(op) => DispatchKernel::compile(&op, plc)?,
             Transpose(op) => DispatchKernel::compile(&op, plc)?,
             Squeeze(op) => DispatchKernel::compile(&op, plc)?,
             FloatingpointMean(op) => DispatchKernel::compile(&op, plc)?,

--- a/moose/src/execution/symbolic.rs
+++ b/moose/src/execution/symbolic.rs
@@ -281,7 +281,6 @@ impl SymbolicStrategy for DefaultSymbolicStrategy {
             FixedpointDecode(op) => DispatchKernel::compile(&op, plc)?(sess, operands),
             FixedpointMean(op) => DispatchKernel::compile(&op, plc)?(sess, operands),
             Identity(op) => DispatchKernel::compile(&op, plc)?(sess, operands),
-            FloatingpointConcat(op) => DispatchKernel::compile(&op, plc)?(sess, operands),
             FloatingpointMean(op) => DispatchKernel::compile(&op, plc)?(sess, operands),
             AtLeast2D(op) => DispatchKernel::compile(&op, plc)?(sess, operands),
             IndexAxis(op) => DispatchKernel::compile(&op, plc)?(sess, operands),

--- a/moose/src/execution/synchronous.rs
+++ b/moose/src/execution/synchronous.rs
@@ -198,7 +198,6 @@ impl Session for SyncSession {
             ExpandDims(op) => DispatchKernel::compile(&op, plc)?(self, operands)?,
             Squeeze(op) => DispatchKernel::compile(&op, plc)?(self, operands)?,
             Sign(op) => DispatchKernel::compile(&op, plc)?(self, operands)?,
-            FloatingpointConcat(op) => DispatchKernel::compile(&op, plc)?(self, operands)?,
             FloatingpointMean(op) => DispatchKernel::compile(&op, plc)?(self, operands)?,
             BitDecompose(op) => DispatchKernel::compile(&op, plc)?(self, operands)?,
             Identity(op) => DispatchKernel::compile(&op, plc)?(self, operands)?,

--- a/moose/src/floatingpoint/ops.rs
+++ b/moose/src/floatingpoint/ops.rs
@@ -322,7 +322,7 @@ impl ExpandDimsOp {
     }
 }
 
-impl FloatingpointConcatOp {
+impl ConcatOp {
     pub(crate) fn float_host_kernel<S: Session, HostFloatT, MirroredT>(
         sess: &S,
         plc: &HostPlacement,

--- a/moose/src/host/ops.rs
+++ b/moose/src/host/ops.rs
@@ -964,7 +964,7 @@ impl SqueezeOp {
 }
 
 impl ConcatOp {
-    pub(crate) fn kernel<S: Session, T: LinalgScalar + FromPrimitive>(
+    pub(crate) fn host_kernel<S: Session, T: LinalgScalar + FromPrimitive>(
         _sess: &S,
         plc: &HostPlacement,
         axis: u32,

--- a/moose/src/kernels/shapes.rs
+++ b/moose/src/kernels/shapes.rs
@@ -101,6 +101,8 @@ pub trait PlacementConcatenate<S: Session, TS, O> {
 }
 
 modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[Tensor] -> Tensor, ConcatOp);
+modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[Float32Tensor] -> Float32Tensor, ConcatOp);
+modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[Float64Tensor] -> Float64Tensor, ConcatOp);
 modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[HostFloat32Tensor] -> HostFloat32Tensor, ConcatOp);
 modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[HostFloat64Tensor] -> HostFloat64Tensor, ConcatOp);
 modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[HostInt8Tensor] -> HostInt8Tensor, ConcatOp);
@@ -109,42 +111,34 @@ modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32
 modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[HostInt64Tensor] -> HostInt64Tensor, ConcatOp);
 modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[HostRing64Tensor] -> HostRing64Tensor, ConcatOp);
 modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[HostRing128Tensor] -> HostRing128Tensor, ConcatOp);
-modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[Float32Tensor] -> Float32Tensor, FloatingpointConcatOp);
-modelled!(PlacementConcatenate::concatenate, HostPlacement, attributes[axis: u32] vec[Float64Tensor] -> Float64Tensor, FloatingpointConcatOp);
-modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedRing64Tensor] -> ReplicatedRing64Tensor, ConcatOp);
-modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedRing128Tensor] -> ReplicatedRing128Tensor, ConcatOp);
-modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedFixed64Tensor] -> ReplicatedFixed64Tensor, ConcatOp);
-modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedFixed128Tensor] -> ReplicatedFixed128Tensor, ConcatOp);
+modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[Tensor] -> Tensor, ConcatOp);
 modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[Fixed64Tensor] -> Fixed64Tensor, ConcatOp);
 modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[Fixed128Tensor] -> Fixed128Tensor, ConcatOp);
-modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[Tensor] -> Tensor, ConcatOp);
+modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedFixed64Tensor] -> ReplicatedFixed64Tensor, ConcatOp);
+modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedFixed128Tensor] -> ReplicatedFixed128Tensor, ConcatOp);
+modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedRing64Tensor] -> ReplicatedRing64Tensor, ConcatOp);
+modelled!(PlacementConcatenate::concatenate, ReplicatedPlacement, attributes[axis: u32] vec[ReplicatedRing128Tensor] -> ReplicatedRing128Tensor, ConcatOp);
 
 kernel! {
     ConcatOp, [
-        (HostPlacement, vec[Tensor] -> Tensor => [concrete] attributes[axis] Self::host_kernel),
-        (HostPlacement, vec[HostFloat32Tensor] -> HostFloat32Tensor => [runtime] attributes[axis] Self::kernel),
-        (HostPlacement, vec[HostFloat64Tensor] -> HostFloat64Tensor => [runtime] attributes[axis] Self::kernel),
-        (HostPlacement, vec[HostInt8Tensor] -> HostInt8Tensor => [runtime] attributes[axis] Self::kernel),
-        (HostPlacement, vec[HostInt16Tensor] -> HostInt16Tensor => [runtime] attributes[axis] Self::kernel),
-        (HostPlacement, vec[HostInt32Tensor] -> HostInt32Tensor => [runtime] attributes[axis] Self::kernel),
-        (HostPlacement, vec[HostInt64Tensor] -> HostInt64Tensor => [runtime] attributes[axis] Self::kernel),
-        (HostPlacement, vec[HostRing64Tensor] -> HostRing64Tensor => [runtime] attributes[axis] Self::ring_kernel),
-        (HostPlacement, vec[HostRing128Tensor] -> HostRing128Tensor => [runtime] attributes[axis] Self::ring_kernel),
-        (ReplicatedPlacement, vec[ReplicatedRing64Tensor] -> ReplicatedRing64Tensor => [concrete] attributes[axis] Self::rep_rep_kernel),
-        (ReplicatedPlacement, vec[ReplicatedRing128Tensor] -> ReplicatedRing128Tensor => [concrete] attributes[axis] Self::rep_rep_kernel),
-        (ReplicatedPlacement, vec[ReplicatedFixed64Tensor] -> ReplicatedFixed64Tensor => [concrete] attributes[axis] Self::rep_fixed_kernel),
-        (ReplicatedPlacement, vec[ReplicatedFixed128Tensor] -> ReplicatedFixed128Tensor => [concrete] attributes[axis] Self::rep_fixed_kernel),
-        (ReplicatedPlacement, vec[Fixed64Tensor] -> Fixed64Tensor => [concrete] attributes[axis] Self::fixed_rep_kernel),
-        (ReplicatedPlacement, vec[Fixed128Tensor] -> Fixed128Tensor => [concrete] attributes[axis] Self::fixed_rep_kernel),
-        (ReplicatedPlacement, vec[Tensor] -> Tensor => [concrete] attributes[axis] Self::logical_rep_kernel),
-    ]
-}
-
-kernel! {
-    FloatingpointConcatOp,
-    [
+        (HostPlacement, vec[Tensor] -> Tensor => [concrete] attributes[axis] Self::logical_host_kernel),
         (HostPlacement, vec[Float32Tensor] -> Float32Tensor => [concrete] attributes[axis] Self::float_host_kernel),
         (HostPlacement, vec[Float64Tensor] -> Float64Tensor => [concrete] attributes[axis] Self::float_host_kernel),
+        (HostPlacement, vec[HostFloat32Tensor] -> HostFloat32Tensor => [runtime] attributes[axis] Self::host_kernel),
+        (HostPlacement, vec[HostFloat64Tensor] -> HostFloat64Tensor => [runtime] attributes[axis] Self::host_kernel),
+        (HostPlacement, vec[HostInt8Tensor] -> HostInt8Tensor => [runtime] attributes[axis] Self::host_kernel),
+        (HostPlacement, vec[HostInt16Tensor] -> HostInt16Tensor => [runtime] attributes[axis] Self::host_kernel),
+        (HostPlacement, vec[HostInt32Tensor] -> HostInt32Tensor => [runtime] attributes[axis] Self::host_kernel),
+        (HostPlacement, vec[HostInt64Tensor] -> HostInt64Tensor => [runtime] attributes[axis] Self::host_kernel),
+        (HostPlacement, vec[HostRing64Tensor] -> HostRing64Tensor => [runtime] attributes[axis] Self::ring_kernel),
+        (HostPlacement, vec[HostRing128Tensor] -> HostRing128Tensor => [runtime] attributes[axis] Self::ring_kernel),
+        (ReplicatedPlacement, vec[Tensor] -> Tensor => [concrete] attributes[axis] Self::logical_rep_kernel),
+        (ReplicatedPlacement, vec[Fixed64Tensor] -> Fixed64Tensor => [concrete] attributes[axis] Self::fixed_rep_kernel),
+        (ReplicatedPlacement, vec[Fixed128Tensor] -> Fixed128Tensor => [concrete] attributes[axis] Self::fixed_rep_kernel),
+        (ReplicatedPlacement, vec[ReplicatedFixed64Tensor] -> ReplicatedFixed64Tensor => [concrete] attributes[axis] Self::rep_fixed_kernel),
+        (ReplicatedPlacement, vec[ReplicatedFixed128Tensor] -> ReplicatedFixed128Tensor => [concrete] attributes[axis] Self::rep_fixed_kernel),
+        (ReplicatedPlacement, vec[ReplicatedRing64Tensor] -> ReplicatedRing64Tensor => [concrete] attributes[axis] Self::rep_rep_kernel),
+        (ReplicatedPlacement, vec[ReplicatedRing128Tensor] -> ReplicatedRing128Tensor => [concrete] attributes[axis] Self::rep_rep_kernel),
     ]
 }
 

--- a/moose/src/logical/ops.rs
+++ b/moose/src/logical/ops.rs
@@ -1251,7 +1251,7 @@ impl IndexAxisOp {
 }
 
 impl ConcatOp {
-    pub(crate) fn host_kernel<S: Session, Fixed64T, Fixed128T, Float32T, Float64T, BoolT>(
+    pub(crate) fn logical_host_kernel<S: Session, Fixed64T, Fixed128T, Float32T, Float64T, BoolT>(
         sess: &S,
         plc: &HostPlacement,
         axis: u32,

--- a/moose/src/textual/mod.rs
+++ b/moose/src/textual/mod.rs
@@ -1126,7 +1126,6 @@ impl ToTextual for Operator {
             FixedpointEncode(op) => op.to_textual(),
             FixedpointDecode(op) => op.to_textual(),
             FixedpointMean(op) => op.to_textual(),
-            FloatingpointConcat(op) => op.to_textual(),
             FloatingpointMean(op) => op.to_textual(),
             RepSetup(op) => op.to_textual(),
             Share(op) => op.to_textual(),


### PR DESCRIPTION
This PR unifies concatenate op. However I tried to use `modelled_kernel!` but couldn't get it work. It was complaining about the syntax, not sure if I made a mistake in the syntax. In theory the macro should support variadic kernel.