### PR TITLE
fixed dependencies so test-ci works for python 3.10

### DIFF
--- a/pymoose/requirements-dev.txt
+++ b/pymoose/requirements-dev.txt
@@ -8,6 +8,6 @@ msgpack==1.0.2
 numpy==1.21.2
 onnx~=1.10.0
 pip~=21.2
-pytest==6.0.1
+pytest==7.0.1
 setuptools-rust~=0.12.1
 wheel~=0.35.1


### PR DESCRIPTION
Pytest 6.0.1 does not work with Python 3.10. This PR upgrades the pytest version to 7.0.1 which does work with Python 3.10.