### PR TITLE
don't return model if error in parsing 

### DIFF
--- a/moose/src/textual/parsing.rs
+++ b/moose/src/textual/parsing.rs
@@ -105,7 +105,9 @@ pub fn parallel_parse_computation(source: &str, chunks: usize) -> anyhow::Result
         .map(|s| {
             parse_operations::<VerboseError<&str>>(s)
                 .map(|t| t.1) // Dropping the remainder
-                .map_err(|e| friendly_error("Failed to parse computation", "base64 encoded model", e))
+                .map_err(|e| {
+                    friendly_error("Failed to parse computation", "base64 encoded model", e)
+                })
         })
         .collect();
     let mut operations = Vec::new();


### PR DESCRIPTION
Related to logs in web service, base64 encoded models are quite large and should not be returned as part of the error. 