### PR TITLE
TreeEnsemble - Validate n_features is greater than split indices

### DIFF
--- a/pymoose/pymoose/predictors/tree_ensemble.py
+++ b/pymoose/pymoose/predictors/tree_ensemble.py
@@ -427,7 +427,7 @@ def _onnx_base(model_proto, forest_node_name):
         raise ValueError(
             f"In the ONNX file, the input shape has {n_features} "
             f"features and there are {n_split_indices} distinct split indices . "
-            f"with the largest indice {largest_split_indices}. Validate you "
+            f"with the largest index {largest_split_indices}. Validate you "
             "set correctly the `initial_types` when converting your model to ONNX."
         )
 


### PR DESCRIPTION
Add check on number of features from the ONNX file to address the comment [here](https://capeprivacy.slack.com/archives/C02SUSM559R/p1646777460651229?thread_ts=1646773388.245649&cid=C02SUSM559R).