### PR TITLE
Cleanup in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ clean:
 ci-ready: fmt lint test-ci
 
 .PHONY: clean-ci
-clean-ci: clean ci-ready
+ci-clean-check: clean ci-ready
 
 .PHONY: release
 release: ci-ready


### PR DESCRIPTION
remove 'cargo clean' from 'ci-ready', inline dependencies for ci-ready and test-ci, mark PHONY at place where defined rather than at end of file