### PR TITLE
Bump Wheel version for macOS BigSur issues

### DIFF
--- a/pymoose/requirements-dev.txt
+++ b/pymoose/requirements-dev.txt
@@ -10,4 +10,4 @@ onnx~=1.10.0
 pip~=21.2
 pytest==7.0.1
 setuptools-rust~=0.12.1
-wheel~=0.35.1
+wheel~=0.36.2


### PR DESCRIPTION
To deal with this issue https://github.com/pypa/wheel/issues/385 where Mac has changed the versioning of its OS and it's breaking a previous assertion statement

