### PR TITLE
setting bytes version to 1

### DIFF
--- a/moose/Cargo.toml
+++ b/moose/Cargo.toml
@@ -26,7 +26,7 @@ bincode = "~1.3"
 bitvec = { version="~1", features=["serde"] }
 blake3 = { version="~1.3", features=["std"] }
 byteorder = "~1.4"
-bytes = "~1.1"
+bytes = "1"
 dashmap = "~5.1"
 derive_more = "~0.99"
 futures = "~0.3"


### PR DESCRIPTION
Having a bytes version of >1.0 caused a problem for dependencies of Kola. Setting `bytes="1"` allows the consumer of moose to use any bytes version >= 1.0.0 and < 2.0.0.