### PR TITLE
Revert "setting bytes version to 1"

### DIFF
--- a/moose/Cargo.toml
+++ b/moose/Cargo.toml
@@ -26,7 +26,7 @@ bincode = "~1.3"
 bitvec = { version="~1", features=["serde"] }
 blake3 = { version="~1.3", features=["std"] }
 byteorder = "~1.4"
-bytes = "1"
+bytes = "~1.1"
 dashmap = "~5.1"
 derive_more = "~0.99"
 futures = "~0.3"


### PR DESCRIPTION
Reverts tf-encrypted/runtime#970

A bit more explanation, the version conflict that inspired this change was non-existent, the downstream project just needed to update its own Cargo.lock.