### PR TITLE
Overwrite output files if it exists

### DIFF
--- a/moose/src/computation.rs
+++ b/moose/src/computation.rs
@@ -1809,8 +1809,8 @@ impl NamedComputation {
     pub fn write_textual<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let file = OpenOptions::new()
             .write(true)
-            .create_new(true)
-            .append(true)
+            .create(true)
+            .truncate(true)
             .open(path)
             .map_err(|e| Error::SerializationError(e.to_string()))?;
 


### PR DESCRIPTION
Closes #986 

This changes the behaviour of `Computation::write_textual` to overwrite any existing file instead of failing. I believe this matches better with expected behaviour.