### PR TITLE
Fix lint

### DIFF
--- a/moose/src/compilation/well_formed.rs
+++ b/moose/src/compilation/well_formed.rs
@@ -44,6 +44,7 @@ pub fn well_formed(comp: Computation) -> anyhow::Result<Computation> {
             Shr(op) => DispatchKernel::compile(op, plc),
             Sample(op) => DispatchKernel::compile(op, plc),
             SampleSeeded(op) => DispatchKernel::compile(op, plc),
+            RingFixedpointAbs(op) => DispatchKernel::compile(op, plc),
             RingFixedpointArgmax(op) => DispatchKernel::compile(op, plc),
             RingFixedpointMean(op) => DispatchKernel::compile(op, plc),
             RingFixedpointEncode(op) => DispatchKernel::compile(op, plc),


### PR DESCRIPTION
GH Actions is not working right now, but I've noticed that the linter is failing on main. This patch fixes it.