### PR TITLE
Make `msgpack` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## v0.2.0
+
+- MsgPack support is now optional via the `msgpack` feature (enabled by default)
+
 ## v0.1.6
+
 - Memory usage optimizations and reduced cloning
 - Wellformed compiler pass to statically verify a computation with elk: elk compile -p wellformed comp.moose
 - TLS support for gRCP networking

--- a/moose/Cargo.toml
+++ b/moose/Cargo.toml
@@ -18,6 +18,13 @@ default = [
     "sync_execute",
     "async_execute",
 ]
+full = [
+    "blas",
+    "msgpack",
+    "compile",
+    "sync_execute",
+    "async_execute",
+]
 blas = ["ndarray-linalg"]
 msgpack = ["rmp-serde"]
 compile = []

--- a/moose/Cargo.toml
+++ b/moose/Cargo.toml
@@ -11,8 +11,15 @@ categories = ["", ""]
 edition = "2018"
 
 [features]
-default = ["blas", "compile", "sync_execute", "async_execute"]
+default = [
+    "blas",
+    "msgpack",
+    "compile",
+    "sync_execute",
+    "async_execute",
+]
 blas = ["ndarray-linalg"]
+msgpack = ["rmp-serde"]
 compile = []
 sync_execute = []
 async_execute = []
@@ -44,7 +51,7 @@ paste = "~1.0"
 petgraph = "~0.6"
 rand = { version = "~0.8", features = ["std", "std_rng"] }
 rayon = "~1.5"
-rmp-serde = "~1.0"
+rmp-serde = { version = "~1.0", optional = true }
 serde = { version="~1.0", features=["derive", "rc"] }
 static_assertions = "~1.1"
 thiserror = "~1.0"

--- a/moose/src/computation.rs
+++ b/moose/src/computation.rs
@@ -1885,7 +1885,7 @@ impl NamedComputation {
     #[cfg(feature = "msgpack")]
     pub fn to_disk<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let mut file_buffer =
-            File::create(path).map_err(|e| Error::SerializationError(e.to_string()))?;
+            std::fs::File::create(path).map_err(|e| Error::SerializationError(e.to_string()))?;
         rmp_serde::encode::write(&mut file_buffer, self)
             .map_err(|e| Error::SerializationError(e.to_string()))?;
         Ok(())

--- a/moose/src/host/ops.rs
+++ b/moose/src/host/ops.rs
@@ -1043,9 +1043,9 @@ impl InverseOp {
         _plc: &HostPlacement,
         _x: HostTensor<T>,
     ) -> Result<HostTensor<T>> {
-        Err(Error::UnimplementedOperator(format!(
-            "Please enable 'blas' feature"
-        )))
+        Err(Error::UnimplementedOperator(
+            "Please enable 'blas' feature".to_string(),
+        ))
     }
 }
 


### PR DESCRIPTION
This PR puts MsgPack support before a `msgpack` feature, saving ~850k lines of LLVM code.

It also adds a new `full` feature that enables everything, allowing us to be more restricted wrt default features.

Before merging we should validate that the benefits are worth having the extra feature. It seems that MsgPack is still needed by Elk and PyMoose, meaning we're essentially only talking about sightly improving the development process.

Closes https://github.com/tf-encrypted/runtime/issues/1020