### PR TITLE
Allow `Apache-2.0 WITH LLVM-exception` licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ unlicensed = "deny"
 allow = [
     "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     # "MPL-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",


### PR DESCRIPTION
Fixes `cargo deny`. Afaict this is a more permissive variant and seems fine. See eg https://spdx.org/licenses/LLVM-exception.html.