### PR TITLE
Add ZerosOp on host a placement

### DIFF
--- a/moose/src/compilation/well_formed.rs
+++ b/moose/src/compilation/well_formed.rs
@@ -74,6 +74,7 @@ pub fn well_formed(comp: Computation) -> anyhow::Result<Computation> {
             Reshape(op) => DispatchKernel::compile(op, plc),
             Slice(op) => DispatchKernel::compile(op, plc),
             Ones(op) => DispatchKernel::compile(op, plc),
+            Zeros(op) => DispatchKernel::compile(op, plc),
             ExpandDims(op) => DispatchKernel::compile(op, plc),
             Concat(op) => DispatchKernel::compile(op, plc),
             Dot(op) => DispatchKernel::compile(op, plc),

--- a/moose/src/computation.rs
+++ b/moose/src/computation.rs
@@ -870,6 +870,7 @@ operators![
     IndexAxis,
     Slice,
     Ones,
+    Zeros,
     ExpandDims,
     Concat,
     Reshape,
@@ -1047,6 +1048,13 @@ pub struct SliceOp {
     Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug, ShortName, ToTextual, FromTextual,
 )]
 pub struct OnesOp {
+    pub sig: Signature,
+}
+
+#[derive(
+    Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug, ShortName, ToTextual, FromTextual,
+)]
+pub struct ZerosOp {
     pub sig: Signature,
 }
 

--- a/moose/src/execution/asynchronous.rs
+++ b/moose/src/execution/asynchronous.rs
@@ -377,6 +377,7 @@ impl DispatchKernel<AsyncSession> for Operator {
             Reshape(op) => DispatchKernel::compile(op, plc),
             Slice(op) => DispatchKernel::compile(op, plc),
             Ones(op) => DispatchKernel::compile(op, plc),
+            Zeros(op) => DispatchKernel::compile(op, plc),
             ExpandDims(op) => DispatchKernel::compile(op, plc),
             Concat(op) => DispatchKernel::compile(op, plc),
             Dot(op) => DispatchKernel::compile(op, plc),

--- a/moose/src/execution/symbolic.rs
+++ b/moose/src/execution/symbolic.rs
@@ -340,6 +340,7 @@ impl SymbolicStrategy for DefaultSymbolicStrategy {
             IndexAxis(op) => DispatchKernel::compile(op, plc)?(sess, operands),
             Slice(op) => DispatchKernel::compile(op, plc)?(sess, operands),
             Ones(op) => DispatchKernel::compile(op, plc)?(sess, operands),
+            Zeros(op) => DispatchKernel::compile(op, plc)?(sess, operands),
             ExpandDims(op) => DispatchKernel::compile(op, plc)?(sess, operands),
             Concat(op) => DispatchKernel::compile(op, plc)?(sess, operands),
             Reshape(op) => DispatchKernel::compile(op, plc)?(sess, operands),

--- a/moose/src/execution/synchronous.rs
+++ b/moose/src/execution/synchronous.rs
@@ -228,6 +228,7 @@ impl Session for SyncSession {
             IndexAxis(op) => DispatchKernel::compile(op, plc)?(self, operands)?,
             Slice(op) => DispatchKernel::compile(op, plc)?(self, operands)?,
             Ones(op) => DispatchKernel::compile(op, plc)?(self, operands)?,
+            Zeros(op) => DispatchKernel::compile(op, plc)?(self, operands)?,
             Concat(op) => DispatchKernel::compile(op, plc)?(self, operands)?,
             Reshape(op) => DispatchKernel::compile(op, plc)?(self, operands)?,
             Transpose(op) => DispatchKernel::compile(op, plc)?(self, operands)?,

--- a/moose/src/floatingpoint/ops.rs
+++ b/moose/src/floatingpoint/ops.rs
@@ -314,6 +314,20 @@ impl OnesOp {
     }
 }
 
+impl ZerosOp {
+    pub(crate) fn host_float_kernel<S: Session, HostFloatT, MirroredT, HostS>(
+        sess: &S,
+        plc: &HostPlacement,
+        shape: HostS,
+    ) -> Result<FloatTensor<HostFloatT, MirroredT>>
+    where
+        HostPlacement: PlacementZeros<S, HostS, HostFloatT>,
+    {
+        let z = plc.zeros(sess, &shape);
+        Ok(FloatTensor::Host(z))
+    }
+}
+
 impl IndexAxisOp {
     pub(crate) fn float_host_kernel<S: Session, HostFloatT, MirroredT>(
         sess: &S,

--- a/moose/src/host/ops.rs
+++ b/moose/src/host/ops.rs
@@ -400,6 +400,17 @@ impl OnesOp {
     }
 }
 
+impl ZerosOp {
+    pub(crate) fn host_kernel<S: RuntimeSession, T: LinalgScalar>(
+        _sess: &S,
+        plc: &HostPlacement,
+        shape: HostShape,
+    ) -> Result<HostTensor<T>> {
+        let raw_shape = shape.0;
+        Ok(HostTensor(ArcArrayD::zeros(raw_shape.0), plc.clone()))
+    }
+}
+
 impl ShapeOp {
     pub(crate) fn host_kernel<S: RuntimeSession, T>(
         _sess: &S,

--- a/moose/src/kernels/constants.rs
+++ b/moose/src/kernels/constants.rs
@@ -250,6 +250,38 @@ modelled_kernel! {
     ]
 }
 
+modelled_kernel! {
+    PlacementZeros::zeros, ZerosOp,
+    [
+        (HostPlacement, (Shape) -> Tensor => [concrete] custom |op| {
+            use crate::logical::{AbstractTensor, TensorDType};
+            match op.sig.ret() {
+                Ty::Tensor(TensorDType::Float32) => Ok(Box::new(move |sess, plc, shape| {
+                    Self::logical_host_kernel::<_, Float32Tensor, _, _>(sess, plc, shape).map(AbstractTensor::Float32)
+                })),
+                Ty::Tensor(TensorDType::Float64) => Ok(Box::new(move |sess, plc, shape| {
+                    Self::logical_host_kernel::<_, Float64Tensor, _, _>(sess, plc, shape).map(AbstractTensor::Float64)
+                })),
+                other => {
+                    return Err(Error::UnimplementedOperator(
+                        format!("Cannot build zeros of type {:?}", other)))
+                },
+            }
+        }),
+        // We do not support the ReplicatedPlacement: PlacementFill yet, hence we do not support Zeros.
+        // Also, logical Tensor can only hold Host tensors at the moment.
+        // (ReplicatedPlacement, (HostShape) -> Tensor => [hybrid] Self::logical_rep_kernel),
+        (HostPlacement, (HostShape) -> Float32Tensor => [hybrid] Self::host_float_kernel),
+        (HostPlacement, (HostShape) -> Float64Tensor => [hybrid] Self::host_float_kernel),
+        (HostPlacement, (HostShape) -> HostFloat32Tensor => [runtime] Self::host_kernel),
+        (HostPlacement, (HostShape) -> HostFloat64Tensor => [runtime] Self::host_kernel),
+        (HostPlacement, (HostShape) -> HostInt8Tensor => [runtime] Self::host_kernel),
+        (HostPlacement, (HostShape) -> HostInt16Tensor => [runtime] Self::host_kernel),
+        (HostPlacement, (HostShape) -> HostInt32Tensor => [runtime] Self::host_kernel),
+        (HostPlacement, (HostShape) -> HostInt64Tensor => [runtime] Self::host_kernel),
+    ]
+}
+
 pub trait PlacementConstant<S: Session, O> {
     fn constant(&self, sess: &S, value: Constant) -> O;
 }

--- a/moose/src/logical/ops.rs
+++ b/moose/src/logical/ops.rs
@@ -1492,6 +1492,28 @@ impl OnesOp {
     }
 }
 
+impl ZerosOp {
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn logical_host_kernel<S: Session, TensorT, HostS, RepS>(
+        sess: &S,
+        plc: &HostPlacement,
+        shape: AbstractShape<HostS, RepS>,
+    ) -> Result<m!(TensorT)>
+    where
+        TensorT: KnownType<S>,
+        HostPlacement: PlacementZeros<S, HostS, m!(TensorT)>,
+        HostPlacement: PlacementReveal<S, RepS, HostS>,
+    {
+        match shape {
+            AbstractShape::Host(sh) => Ok(plc.zeros(sess, &sh)),
+            AbstractShape::Replicated(sh) => {
+                let sh = plc.reveal(sess, &sh);
+                Ok(plc.zeros(sess, &sh))
+            }
+        }
+    }
+}
+
 impl ExpandDimsOp {
     pub(crate) fn logical_host_kernel<
         S: Session,

--- a/moose/src/textual/parsing.rs
+++ b/moose/src/textual/parsing.rs
@@ -1188,6 +1188,7 @@ impl ToTextual for Operator {
             IndexAxis(op) => op.to_textual(),
             Slice(op) => op.to_textual(),
             Ones(op) => op.to_textual(),
+            Zeros(op) => op.to_textual(),
             ExpandDims(op) => op.to_textual(),
             Concat(op) => op.to_textual(),
             Reshape(op) => op.to_textual(),

--- a/pymoose/pymoose/computation/operations.py
+++ b/pymoose/pymoose/computation/operations.py
@@ -4,8 +4,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-import numpy as np
-
 from pymoose.computation import types as ty
 from pymoose.computation import values
 
@@ -129,7 +127,12 @@ class SqueezeOperation(Operation):
 
 @dataclass
 class OnesOperation(Operation):
-    dtype: Optional[Union[float, np.float64, int, np.int64]]
+    pass
+
+
+@dataclass
+class ZerosOperation(Operation):
+    pass
 
 
 @dataclass

--- a/pymoose/pymoose/computation/utils.py
+++ b/pymoose/pymoose/computation/utils.py
@@ -40,6 +40,7 @@ SUPPORTED_TYPES = [
     ops.MulOperation,
     ops.MuxOperation,
     ops.OnesOperation,
+    ops.ZerosOperation,
     ops.OutputOperation,
     ops.SigmoidOperation,
     ops.SoftmaxOperation,
@@ -146,8 +147,7 @@ def _decode(obj):
             }[dtype_name]
         elif obj["__type__"] == "OpSignature":
             return ops.OpSignature(
-                input_types=obj["input_types"],
-                return_type=obj["return_type"],
+                input_types=obj["input_types"], return_type=obj["return_type"],
             )
         elif obj["__type__"] == "ndarray":
             dtype = obj["dtype"]

--- a/pymoose/pymoose/edsl/base.py
+++ b/pymoose/pymoose/edsl/base.py
@@ -96,7 +96,7 @@ class Argument:
 @dataclass
 class Expression:
     placement: PlacementExpression
-    inputs: List
+    inputs: List["Expression"]
     vtype: Optional[ty.ValueType]
 
     def __hash__(self):
@@ -177,8 +177,12 @@ class SqueezeExpression(Expression):
 
 @dataclass
 class OnesExpression(Expression):
-    dtype: dtypes.DType
+    def __hash__(self):
+        return id(self)
 
+
+@dataclass
+class ZerosExpression(Expression):
     def __hash__(self):
         return id(self)
 
@@ -454,9 +458,7 @@ def decrypt(key, ciphertext, placement=None):
     output_type = ty.TensorType(output_dtype)
 
     return DecryptExpression(
-        placement=placement,
-        inputs=[key, ciphertext],
-        vtype=output_type,
+        placement=placement, inputs=[key, ciphertext], vtype=output_type,
     )
 
 
@@ -612,7 +614,14 @@ def ones(shape, dtype, placement=None):
     assert isinstance(shape, Expression)
     placement = placement or get_current_placement()
     vtype = ty.TensorType(dtype)
-    return OnesExpression(placement=placement, inputs=[shape], dtype=dtype, vtype=vtype)
+    return OnesExpression(placement=placement, inputs=[shape], vtype=vtype)
+
+
+def zeros(shape, dtype, placement=None):
+    assert isinstance(shape, Expression)
+    placement = placement or get_current_placement()
+    vtype = ty.TensorType(dtype)
+    return ZerosExpression(placement=placement, inputs=[shape], vtype=vtype)
 
 
 def square(x, placement=None):
@@ -672,11 +681,7 @@ def argmax(x, axis, upmost_index, placement=None):
 def log(x, placement=None):
     assert isinstance(x, Expression)
     placement = placement or get_current_placement()
-    return LogExpression(
-        placement=placement,
-        inputs=[x],
-        vtype=x.vtype,
-    )
+    return LogExpression(placement=placement, inputs=[x], vtype=x.vtype,)
 
 
 def log2(x, placement=None):

--- a/pymoose/pymoose/edsl/base_test.py
+++ b/pymoose/pymoose/edsl/base_test.py
@@ -50,8 +50,7 @@ class EdslTest(parameterized.TestCase):
             name="identity_0",
             inputs={"x": "constant_0"},
             signature=ops.OpSignature(
-                {"x": ty.TensorType(dtypes.float64)},
-                ty.TensorType(dtypes.float64),
+                {"x": ty.TensorType(dtypes.float64)}, ty.TensorType(dtypes.float64),
             ),
         )
 
@@ -164,7 +163,27 @@ class EdslTest(parameterized.TestCase):
         assert op == ops.OnesOperation(
             placement_name="player0",
             name="ones_0",
-            dtype=dtypes.float64,
+            inputs={"shape": "constant_0"},
+            signature=ops.OpSignature(
+                input_types={"shape": ty.ShapeType()},
+                return_type=ty.TensorType(dtype=dtypes.float64),
+            ),
+        )
+
+    def test_zeros(self):
+        player0 = edsl.host_placement(name="player0")
+
+        @edsl.computation
+        def my_comp():
+            shape = edsl.constant([2, 2], vtype=ty.ShapeType(), placement=player0)
+            x0 = edsl.zeros(shape, dtype=dtypes.float64, placement=player0)
+            return x0
+
+        concrete_comp = trace(my_comp)
+        op = concrete_comp.operation("zeros_0")
+        assert op == ops.ZerosOperation(
+            placement_name="player0",
+            name="zeros_0",
             inputs={"shape": "constant_0"},
             signature=ops.OpSignature(
                 input_types={"shape": ty.ShapeType()},
@@ -225,8 +244,7 @@ class EdslTest(parameterized.TestCase):
             axis=axis,
             inputs={"x": "constant_0"},
             signature=ops.OpSignature(
-                {"x": ty.TensorType(dtypes.float32)},
-                ty.TensorType(dtypes.float32),
+                {"x": ty.TensorType(dtypes.float32)}, ty.TensorType(dtypes.float32),
             ),
         )
 
@@ -249,8 +267,7 @@ class EdslTest(parameterized.TestCase):
             axes=None,
             inputs={"x": "constant_0"},
             signature=ops.OpSignature(
-                {"x": ty.TensorType(dtypes.float32)},
-                ty.TensorType(dtypes.float32),
+                {"x": ty.TensorType(dtypes.float32)}, ty.TensorType(dtypes.float32),
             ),
         )
 
@@ -280,9 +297,7 @@ class EdslTest(parameterized.TestCase):
             ),
         )
 
-    @parameterized.parameters(
-        (np.array(1), np.array([[1]])),
-    )
+    @parameterized.parameters((np.array(1), np.array([[1]])),)
     def test_atleast_2d(self, x, expected):
         player0 = edsl.host_placement(name="player0")
 
@@ -301,8 +316,7 @@ class EdslTest(parameterized.TestCase):
             inputs={"x": "constant_0"},
             to_column_vector=True,
             signature=ops.OpSignature(
-                {"x": ty.TensorType(dtypes.float64)},
-                ty.TensorType(dtypes.float64),
+                {"x": ty.TensorType(dtypes.float64)}, ty.TensorType(dtypes.float64),
             ),
         )
 
@@ -327,8 +341,7 @@ class EdslTest(parameterized.TestCase):
             inputs={"x": "constant_0"},
             axis=axis,
             signature=ops.OpSignature(
-                {"x": ty.TensorType(dtypes.int64)},
-                ty.TensorType(dtypes.int64),
+                {"x": ty.TensorType(dtypes.int64)}, ty.TensorType(dtypes.int64),
             ),
         )
 
@@ -354,8 +367,7 @@ class EdslTest(parameterized.TestCase):
             axis=1,
             index=0,
             signature=ops.OpSignature(
-                {"x": ty.TensorType(dtypes.float64)},
-                ty.TensorType(dtypes.float64),
+                {"x": ty.TensorType(dtypes.float64)}, ty.TensorType(dtypes.float64),
             ),
         )
 
@@ -382,8 +394,7 @@ class EdslTest(parameterized.TestCase):
             inputs={"x": "constant_0"},
             axis=axis,
             signature=ops.OpSignature(
-                {"x": ty.TensorType(dtypes.float64)},
-                ty.TensorType(dtypes.float64),
+                {"x": ty.TensorType(dtypes.float64)}, ty.TensorType(dtypes.float64),
             ),
         )
 
@@ -613,8 +624,7 @@ class EdslTest(parameterized.TestCase):
             name="cast_0",
             inputs={"x": "constant_0"},
             signature=ops.OpSignature(
-                {"x": ty.TensorType(from_dtype)},
-                ty.TensorType(into_dtype),
+                {"x": ty.TensorType(from_dtype)}, ty.TensorType(into_dtype),
             ),
         )
 
@@ -647,8 +657,7 @@ class EdslTest(parameterized.TestCase):
             name="cast_0",
             inputs={"x": "constant_0"},
             signature=ops.OpSignature(
-                {"x": ty.TensorType(from_dtype)},
-                ty.TensorType(dtype),
+                {"x": ty.TensorType(from_dtype)}, ty.TensorType(dtype),
             ),
         )
 

--- a/pymoose/pymoose/edsl/tracer.py
+++ b/pymoose/pymoose/edsl/tracer.py
@@ -141,10 +141,7 @@ class AstTracer:
                 placement_name=placement.name,
                 name=argument_expression.arg_name,
                 inputs={},
-                signature=ops.OpSignature(
-                    input_types={},
-                    return_type=output_type,
-                ),
+                signature=ops.OpSignature(input_types={}, return_type=output_type,),
             )
         )
 
@@ -184,8 +181,7 @@ class AstTracer:
                 axis=concatenate_expression.axis,
                 inputs=array_inputs,
                 signature=ops.OpSignature(
-                    input_types=array_types,
-                    return_type=concatenate_expression.vtype,
+                    input_types=array_types, return_type=concatenate_expression.vtype,
                 ),
             )
         )
@@ -205,8 +201,7 @@ class AstTracer:
                 name=self.get_fresh_name("maximum"),
                 inputs=array_inputs,
                 signature=ops.OpSignature(
-                    input_types=array_types,
-                    return_type=maximum_expression.vtype,
+                    input_types=array_types, return_type=maximum_expression.vtype,
                 ),
             )
         )
@@ -485,16 +480,31 @@ class AstTracer:
         (shape_expression,) = ones_expression.inputs
         shape_operation = self.visit(shape_expression)
         placement = self.visit_placement_expression(ones_expression.placement)
-        dtype = ones_expression.dtype
         return self.computation.add_operation(
             ops.OnesOperation(
                 placement_name=placement.name,
                 name=self.get_fresh_name("ones"),
-                dtype=dtype,
                 inputs={"shape": shape_operation.name},
                 signature=ops.OpSignature(
                     input_types={"shape": shape_operation.return_type},
                     return_type=ones_expression.vtype,
+                ),
+            )
+        )
+
+    def visit_ZerosExpression(self, zeros_expression):
+        assert isinstance(zeros_expression, expr.ZerosExpression)
+        (shape_expression,) = zeros_expression.inputs
+        shape_operation = self.visit(shape_expression)
+        placement = self.visit_placement_expression(zeros_expression.placement)
+        return self.computation.add_operation(
+            ops.ZerosOperation(
+                placement_name=placement.name,
+                name=self.get_fresh_name("zeros"),
+                inputs={"shape": shape_operation.name},
+                signature=ops.OpSignature(
+                    input_types={"shape": shape_operation.return_type},
+                    return_type=zeros_expression.vtype,
                 ),
             )
         )


### PR DESCRIPTION
This PR adds a ZerosOp on a host placement, i.e.: creates a vector of zeros of a given length.
Test for edsl.zeros() in edsl/base_test.py passes. The implementation closely follows the OnesOp implementation.