### PR TITLE
Debug print sending and receiving in `GrpcNetworking`

### DIFF
--- a/modules/src/networking/grpc.rs
+++ b/modules/src/networking/grpc.rs
@@ -123,6 +123,8 @@ impl AsyncNetworking for GrpcNetworking {
                 };
                 let channel = self.channel(receiver)?;
                 let mut client = NetworkingClient::new(channel);
+                #[cfg(debug_assertions)]
+                tracing::debug!("Sending '{}' to {}", rendezvous_key, receiver);
                 let _response = client
                     .send_value(request)
                     .await
@@ -154,10 +156,16 @@ impl AsyncNetworking for GrpcNetworking {
                         sender, actual_sender
                     )))
                 } else {
+                    #[cfg(debug_assertions)]
+                    tracing::debug!("Received '{}' from {}", rendezvous_key, sender);
                     Ok(value)
                 }
             }
-            None => Ok(value),
+            None => {
+                #[cfg(debug_assertions)]
+                tracing::debug!("Received '{}' from {}", rendezvous_key, sender);
+                Ok(value)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/tf-encrypted/moose/issues/1100

One consideration is that this might slow down large computations in debug mode. An alternative could be to not condition on `debug_assertions` but instead introduce an explicit feature.