### PR TITLE
Fix output expr tracing

### DIFF
--- a/pymoose/pymoose/__init__.py
+++ b/pymoose/pymoose/__init__.py
@@ -44,6 +44,7 @@ from pymoose.edsl.base import mirrored_placement
 from pymoose.edsl.base import mul
 from pymoose.edsl.base import mux
 from pymoose.edsl.base import ones
+from pymoose.edsl.base import output
 from pymoose.edsl.base import relu
 from pymoose.edsl.base import replicated_placement
 from pymoose.edsl.base import reshape
@@ -115,6 +116,7 @@ __all__ = [
     mux,
     MooseComputation,
     ones,
+    output,
     predictors,
     relu,
     replicated_placement,

--- a/pymoose/pymoose/edsl/base_test.py
+++ b/pymoose/pymoose/edsl/base_test.py
@@ -836,6 +836,29 @@ class EdslTest(parameterized.TestCase):
             ),
         )
 
+    def test_tagged_output(self):
+        player0 = edsl.host_placement(name="player0")
+
+        @edsl.computation
+        def my_comp():
+            with player0:
+                x = edsl.constant(np.array([1.0]), dtype=dtypes.float64)
+                x = edsl.output("x", x)
+                return x
+
+        concrete_comp = trace(my_comp)
+        output_op = concrete_comp.operation("output_0")
+        assert output_op == ops.OutputOperation(
+            placement_name="player0",
+            name="output_0",
+            inputs={"value": "constant_0"},
+            signature=ops.OpSignature(
+                {"value": ty.TensorType(dtypes.float64)},
+                ty.TensorType(dtypes.float64),
+            ),
+            tag="x",
+        )
+
 
 def _npdtype_into_moose_dtype(npdtype):
     return edsl._NUMPY_DTYPES_MAP[npdtype]

--- a/pymoose/pymoose/edsl/tracer.py
+++ b/pymoose/pymoose/edsl/tracer.py
@@ -45,9 +45,9 @@ class AstTracer:
         if not isinstance(expressions, (tuple, list)):
             expressions = [expressions]
         for expression in expressions:
-            output_name = self.get_fresh_name("output")
             op = self.visit(expression)
             if not isinstance(op, ops.OutputOperation):
+                output_name = self.get_fresh_name("output")
                 self.computation.add_operation(
                     ops.OutputOperation(
                         name=output_name,
@@ -798,7 +798,7 @@ class AstTracer:
                 inputs={"value": value_operation.name},
                 signature=ops.OpSignature(
                     input_types={"value": value_operation.return_type},
-                    return_type=ty.UnitType(),
+                    return_type=value_operation.return_type,
                 ),
                 tag=output_expression.tag,
             )


### PR DESCRIPTION
In #1126 there was a bug when tracing explicitly tagged output expressions, which resulted in the OutputOp having HostUnit return type in its signature. Verified the fix with a test here. Also, this change exposes the `edsl.output` function in the root `pymoose` namespace.