### PR TITLE
Fix typos in tutorial

### DIFF
--- a/tutorials/scientific-computing-multiple-players.ipynb
+++ b/tutorials/scientific-computing-multiple-players.ipynb
@@ -27,12 +27,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Use case\n",
     "\n",
-    "Here is the use case we are trying to solve : researchers would like to measure the correlation between alcohol consumption and students' grades. However the alcohol consumption data and grades data are owned respectively by the Department of Public Health and the Department of Education. These datasets are too sensitive to be moved to a central location or exposed directly to the researchers. To solve this problem, we want to compute the correlation metric on an encrypted version of these datasets. "
+    "Here is the use case we are trying to solve: researchers would like to measure the correlation between alcohol consumption and students' grades. However the alcohol consumption data and grades data are owned respectively by the Department of Public Health and the Department of Education. These datasets are too sensitive to be moved to a central location or exposed directly to the researchers. To solve this problem, we want to compute the correlation metric on an encrypted version of these datasets. "
    ]
   },
   {
@@ -53,7 +54,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Acohol consumption data from Departement of Public Health: [11.06803447  9.58819631  6.28498731  9.63183684 11.17578054]\n",
+      "Alcohol consumption data from Departement of Public Health: [11.06803447  9.58819631  6.28498731  9.63183684 11.17578054]\n",
       "Grades data from Departement of Education: [ 0.71290544  2.16473508  2.78613359 -2.32336413  0.4538998 ]\n"
      ]
     }
@@ -75,7 +76,7 @@
     "alcohol_consumption, grades = generate_synthetic_correlated_data(100)\n",
     "\n",
     "print(\n",
-    "    f\"Acohol consumption data from Departement of Public Health: {alcohol_consumption[:5]}\"\n",
+    "    f\"Alcohol consumption data from Departement of Public Health: {alcohol_consumption[:5]}\"\n",
     ")\n",
     "print(f\"Grades data from Departement of Education: {grades[:5]}\")"
    ]
@@ -132,19 +133,19 @@
     "@pm.computation\n",
     "def multiparty_correlation():\n",
     "\n",
-    "    # Department of Public Health load the data in plaintext\n",
-    "    # Then the data gets converted from float to fixed-point\n",
+    "    # Department of Public Health loads the data in plaintext\n",
+    "    # Then the data get converted from float to fixed-point\n",
     "    with pub_health_dpt:\n",
     "        alcohol = pm.load(\"alcohol_data\", dtype=pm.float64)\n",
     "        alcohol = pm.cast(alcohol, dtype=fixedpoint_dtype)\n",
     "\n",
-    "    # Department of Education load the data in plaintext\n",
-    "    # Then the data gets converted from float to fixed-point\n",
+    "    # Department of Education loads the data in plaintext\n",
+    "    # Then the data get converted from float to fixed-point\n",
     "    with education_dpt:\n",
     "        grades = pm.load(\"grades_data\", dtype=pm.float64)\n",
     "        grades = pm.cast(grades, dtype=fixedpoint_dtype)\n",
     "\n",
-    "    # Alcohol and grades data gets secret shared when moving from host placement\n",
+    "    # Alcohol and grades data get secret shared when moving from host placement\n",
     "    # to replicated placement.\n",
     "    # Then compute the correlation coefficient on secret shared data\n",
     "    with encrypted_governement:\n",
@@ -264,6 +265,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -279,7 +281,7 @@
     "\n",
     "For the data, we will use the numpy files saved in the `data` folder of this tutorial containing the alcohol consumption data (`alcohol_consumption.npy`) and grades data (`grades.npy`).\n",
     "\n",
-    "For the Moose computation, we will use is exact the same computation as the one used with `LocalMooseRuntime` except for the key of the load operations we will provide the actual file path. "
+    "For the Moose computation, we will use exactly the same computation as the one used with `LocalMooseRuntime` except for the key of the load operations we will provide the actual file path. "
    ]
   },
   {
@@ -297,19 +299,19 @@
     "@pm.computation\n",
     "def multiparty_correlation():\n",
     "\n",
-    "    # Department of Public Health load the data in plaintext\n",
-    "    # Then the data gets converted from float to fixed-point\n",
+    "    # Department of Public Health loads the data in plaintext\n",
+    "    # Then the data get converted from float to fixed-point\n",
     "    with pub_health_dpt:\n",
     "        alcohol = pm.load(alcohol_consumption_path, dtype=pm.float64)\n",
     "        alcohol = pm.cast(alcohol, dtype=fixedpoint_dtype)\n",
     "\n",
-    "    # Department of Education load the data in plaintext\n",
-    "    # Then the data gets converted from float to fixed-point\n",
+    "    # Department of Education loads the data in plaintext\n",
+    "    # Then the data get converted from float to fixed-point\n",
     "    with education_dpt:\n",
     "        grades = pm.load(grades_path, dtype=pm.float64)\n",
     "        grades = pm.cast(grades, dtype=fixedpoint_dtype)\n",
     "\n",
-    "    # Alcohol and grades data gets secret shared when moving from host placement\n",
+    "    # Alcohol and grades data get secret shared when moving from host placement\n",
     "    # to replicated placement.\n",
     "    # Then compute the correlation coefficient on secret shared data\n",
     "    with encrypted_governement:\n",
@@ -377,7 +379,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.10 ('venv': venv)",
+   "display_name": "pymoose",
    "language": "python",
    "name": "python3"
   },
@@ -391,12 +393,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6 (main, Nov 14 2022, 16:10:14) [GCC 11.3.0]"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "c8976be5a03b0df451cc69cfc419fd7b54b63440241bc817605cfae539201d9c"
+    "hash": "c8c600ba18f247aba3c656127b2d8044e5959fc70dcf6730503a66e662a15594"
    }
   }
  },


### PR DESCRIPTION
Fix some typos in `tutorials/scientific-computing-multiple-players.ipynb`