### PR TITLE
Bump tokio

### DIFF
--- a/moose/Cargo.toml
+++ b/moose/Cargo.toml
@@ -76,7 +76,7 @@ serde = { version = "~1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 static_assertions = "~1.1"
 thiserror = "~1.0"
-tokio = { version = "~1.21", features = ["full"] }
+tokio = { version = "~1.23.1", features = ["full"] }
 toml = "0.5"
 tonic = { version = "~0.8", features = ["tls"] }
 tracing = { version = "~0.1", features = ["log"] }


### PR DESCRIPTION
using the newest patch of tokio ensures we never fall into the issue of https://github.com/advisories/GHSA-7rrj-xr53-82p7
note we weren't using the vulnerable code to begin with, this is just a precaution